### PR TITLE
order first few returned query rows by the order of search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,22 @@ from flask.ext.whooshee import Whooshee
 w = Whooshee(app)
 w.reindex()
 ```
+### Seach results ordering
+
+By default only first 10 (for optimization reasons) search results are sorted by relevance.
+You can modify this behaviour by explicitly setting the value of `order_by_relevance`
+parameter of the `whooshee_search` method.
+
+```
+# return all search results sorted by relevance (only Chuck Norris can do this)
+Entry.query.join(User).whooshee_search('chuck norris', order_by_relevance=-1).all()
+
+# disable sorting altogether
+Entry.query.join(User).whooshee_search('chuck norris', order_by_relevance=0).all()
+
+# return first 25 rows sorted by their relevance
+Entry.query.join(User).whooshee_search('chuck norris', order_by_relevance=25).all()
+```
 
 
 Project is in early alpha stage, documentation and more functionality will be landing soon.

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ from flask.ext.whooshee import Whooshee
 w = Whooshee(app)
 w.reindex()
 ```
-### Seach results ordering
+### Search results ordering
 
 By default only first 10 (for optimization reasons) search results are sorted by relevance.
 You can modify this behaviour by explicitly setting the value of `order_by_relevance`
 parameter of the `whooshee_search` method.
 
-```
+```python
 # return all search results sorted by relevance (only Chuck Norris can do this)
 Entry.query.join(User).whooshee_search('chuck norris', order_by_relevance=-1).all()
 

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -19,7 +19,7 @@ class WhoosheeQuery(BaseQuery):
 
     # TODO: add an option to override used Whoosheer
     def whooshee_search(self, search_string, group=whoosh.qparser.OrGroup,
-                        match_substrings=True, limit=None, order_by_relevance=-1):
+                        match_substrings=True, limit=None, order_by_relevance=10):
         """Do a fulltext search on the query.
 
         Args:

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 
+import sqlalchemy
+
 import whoosh
 import whoosh.fields
 import whoosh.index
@@ -72,7 +74,11 @@ class WhoosheeQuery(BaseQuery):
                 if m.__name__.lower() == uniq.split('_')[0]:
                     attr = getattr(m, uniq.split('_')[1])
 
-        return self.filter(attr.in_(res))
+        order_by_expr = sqlalchemy.sql.expression.case(
+            [(attr == uniq_val, index) for index, uniq_val in enumerate(res)]
+        )
+
+        return self.filter(attr.in_(res)).order_by(order_by_expr)
 
 class AbstractWhoosheer(object):
     """A superclass for all whoosheers.

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -74,8 +74,9 @@ class WhoosheeQuery(BaseQuery):
                 if m.__name__.lower() == uniq.split('_')[0]:
                     attr = getattr(m, uniq.split('_')[1])
 
-        order_by_expr = sqlalchemy.sql.expression.case(
-            [(attr == uniq_val, index) for index, uniq_val in enumerate(res)]
+        order_by_expr = sqlalchemy.sql.expression.case( # return first few rows in order
+            [(attr == uniq_val, index) for index, uniq_val in enumerate(res) if index < 10],
+            else_=10
         )
 
         return self.filter(attr.in_(res)).order_by(order_by_expr)

--- a/test.py
+++ b/test.py
@@ -159,7 +159,7 @@ class BaseTestCases(object):
 
             search_string = u' '.join([string.ascii_lowercase[i]*3 for i in range(26)])
 
-            # no sorting (this assumes (hopes) rows won't returned in the correct order by default)
+            # no sorting (this assumes (hopes) rows won't be returned in the correct order by default)
             found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=0).all()
             titles = [int(entry.title) for entry in found_entries]
             self.assertNotEqual(titles, sorted(titles, reverse=True))
@@ -169,7 +169,7 @@ class BaseTestCases(object):
             titles = [int(entry.title) for entry in found_entries]
             self.assertEqual(titles, sorted(titles, reverse=True))
 
-            # sort some (this assumes (hopes) the rest of the rows won't returned in the correct order by default)
+            # sort some (this assumes (hopes) the rest of the rows won't be returned in the correct order by default)
             found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=20).all()
             titles = [int(entry.title) for entry in found_entries]
             self.assertNotEqual(titles, sorted(titles, reverse=True))

--- a/test.py
+++ b/test.py
@@ -179,6 +179,16 @@ class BaseTestCases(object):
             titles = [int(entry.title) for entry in found_entries]
             self.assertEqual(titles, sorted(titles, reverse=True))
 
+            # order_by after whooshee_search (note: order_by following whooshee_search has no impact for the first n results)
+            found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=26).order_by(self.Entry.id).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertEqual(titles, sorted(titles, reverse=True))
+
+            # order_by before whooshee_search (note: order_by is a primary criterion here and search ordering is secondary)
+            found_entries = self.Entry.query.order_by(self.Entry.id).whooshee_search(search_string, order_by_relevance=26).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertEqual(titles, sorted(titles))
+
         def test_reindex(self):
             self.db.session.add_all(self.all_inst)
             self.db.session.commit()

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 from unittest import TestCase
+import string
 
 import whoosh
 from flask import Flask
@@ -130,6 +131,8 @@ class BaseTestCases(object):
             # couldn't test for large set due to some bugs either in sqlite or whoosh or SA
             # got: OperationalError: (OperationalError) too many SQL variables u'SELECT entry.id
             #  ... FROM entry \nWHERE entry.id IN (?, ?, .... when whooshee_search is invoked
+            #
+            # NOTE: This is caused by sqlite db paramater SQLITE_LIMIT_VARIABLE_NUMBER being set to 999 by default
             for batch_size in [2, 5, 7, 20, 50, 300, 500]:  # , 1000]:
                 expected_count += batch_size
                 self.entry_list = [
@@ -141,8 +144,40 @@ class BaseTestCases(object):
                 self.db.session.add_all(self.entry_list)
                 self.db.session.commit()
 
-                found = self.Entry.query.whooshee_search('foobar').all()
+                found = self.Entry.query.whooshee_search('foobar', order_by_relevance=0).all()
                 assert len(found) == expected_count
+
+        def test_order_by_relevance(self):
+            entries_to_add = []
+
+            for x in range(1, len(string.ascii_lowercase)+1):
+                content = u' '.join([string.ascii_lowercase[i]*3 for i in range(x)])
+                entries_to_add.append(self.Entry(title=u'{0}'.format(x), content=content, user=self.u1))
+
+            self.db.session.add_all(entries_to_add)
+            self.db.session.commit()
+
+            search_string = u' '.join([string.ascii_lowercase[i]*3 for i in range(26)])
+
+            # no sorting (this assumes (hopes) rows won't returned in the correct order by default)
+            found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=0).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertNotEqual(titles, sorted(titles, reverse=True))
+
+            # sort all
+            found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=-1).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertEqual(titles, sorted(titles, reverse=True))
+
+            # sort some (this assumes (hopes) the rest of the rows won't returned in the correct order by default)
+            found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=20).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertNotEqual(titles, sorted(titles, reverse=True))
+
+            # sort all (by setting order_by_relevance to the number of returned search results)
+            found_entries = self.Entry.query.whooshee_search(search_string, order_by_relevance=26).all()
+            titles = [int(entry.title) for entry in found_entries]
+            self.assertEqual(titles, sorted(titles, reverse=True))
 
         def test_reindex(self):
             self.db.session.add_all(self.all_inst)


### PR DESCRIPTION
This pull request makes results of query.whooshee_search() ordered (at least first 10 rows currently), which provides better search results for the end user.