### PR TITLE
added whoosheer option for whooshee_search method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ Now you can search join queries like this:
 Entry.query.join(User).whooshee_search('chuck norris').order_by(Entry.id.desc()).all()
 ```
 
+The whoosheer that is used for searching is, by default, selected based on the models participating in the query.
+This set of models is compared against the value of `models` attribute of each registered whoosheer and the one
+with an exact match is selected. You can override this behaviour by explicitly passing whoosheer that should be
+used for searching to the `whooshee_search` method. This is useful if you don't want to join on all the models that
+form the search index. For example:
+```python
+Entry.query.whooshee_search('chuck norris', whoosheer=EntryUserWhoosheer).order_by(Entry.id.desc()).all()
+```
+If there exists an entry of a user called 'chuck norris', this entry will be found because the custom whoosheer, that contains field `username`, will be used. But without the whoosheer option, that entry won't be found (unless it has 'chuck&nbsp;norris' in content or title) because the model whoosheer will be used.
+
 ### Reindex
 
 Available since v0.0.9.

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -17,8 +17,7 @@ from sqlalchemy.orm.mapper import Mapper
 class WhoosheeQuery(BaseQuery):
     """An override for SQLAlchemy query used to do fulltext search."""
 
-    # TODO: add an option to override used Whoosheer
-    def whooshee_search(self, search_string, group=whoosh.qparser.OrGroup,
+    def whooshee_search(self, search_string, group=whoosh.qparser.OrGroup, whoosheer=None,
                         match_substrings=True, limit=None, order_by_relevance=10):
         """Do a fulltext search on the query.
 
@@ -32,21 +31,22 @@ class WhoosheeQuery(BaseQuery):
         Returns:
             query filtered with results of the fulltext search
         """
-        ### inspiration taken from flask-WhooshAlchemy
-        # find out all entities in join
-        entities = set()
-        # directly queried entities
-        for cd in self.column_descriptions:
-            entities.add(cd['type'])
-        # joined entities
-        if self._join_entities and isinstance(self._join_entities[0], Mapper):
-            # SQLAlchemy >= 0.8.0
-            entities.update(set([x.entity for x in self._join_entities]))
-        else:
-            # SQLAlchemy < 0.8.0
-            entities.update(set(self._join_entities))
+        if not whoosheer:
+            ### inspiration taken from flask-WhooshAlchemy
+            # find out all entities in join
+            entities = set()
+            # directly queried entities
+            for cd in self.column_descriptions:
+                entities.add(cd['type'])
+            # joined entities
+            if self._join_entities and isinstance(self._join_entities[0], Mapper):
+                # SQLAlchemy >= 0.8.0
+                entities.update(set([x.entity for x in self._join_entities]))
+            else:
+                # SQLAlchemy < 0.8.0
+                entities.update(set(self._join_entities))
 
-        whoosheer = next(w for w in Whooshee.whoosheers if set(w.models) == entities)
+            whoosheer = next(w for w in Whooshee.whoosheers if set(w.models) == entities)
 
         # TODO what if unique field doesn't exist or there are multiple?
         for fname, field in list(whoosheer.schema._fields.items()):


### PR DESCRIPTION
Hello, this commits adds possiblity to override whoosheer when whooshee_searching :). This can be useful if we want to include data into a search index from a model we don't join on. See, for instance, https://github.com/fedora-copr/copr/commit/77eb46f7 for a concrete usecase.