### PR TITLE
optimized on_commit method

### DIFF
--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -265,12 +265,17 @@ class Whooshee(object):
         to do the actual index writing.
         """
         for wh in self.__class__.whoosheers:
-            writer = wh.index.writer(timeout=self.writer_timeout)
+            writer = None
             for change in changes:
                 if change[0].__class__ in wh.models:
                     method_name = '{0}_{1}'.format(change[1], change[0].__class__.__name__.lower())
-                    getattr(wh, method_name)(writer, change[0])
-            writer.commit()
+                    method = getattr(wh, method_name, None)
+                    if method:
+                        if not writer:
+                            writer = wh.index.writer(timeout=self.writer_timeout)
+                        method(writer, change[0])
+            if writer:
+                writer.commit()
 
     def camel_to_snake(self, s):
         """Constructs nice dir name from class name, e.g. FooBar => foo_bar."""


### PR DESCRIPTION
Do not lock search index if:

- all the changed models are actually unregistered (not part of the whoosheer)
- the appropriate index update method is missing from the whoosheer (e.g. update_xyz where update of xyz cannot in fact change search index)

In our system (COPR), search index update times are pretty high (around 1s) and we needed to avoid unnecessary index locks on operations like user login, where `User` model is changed (because his last login timestamp is changed) but our update_user in the Whoosheer did in fact nothing because username (only indexed attribute of `User`) cannot be changed. Also we wanted to avoid index locking when entirely different not indexed model was updated. 

(Note that search index is locked when the writer instance is created.)