### PR TITLE
auto_update class attribute added for AbstractWhoosheer

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -263,6 +263,24 @@ reindex your data::
 
 .. versionadded::  v0.0.9
 
+Manual index updates
+--------------------
+
+If your application depends heavily on write operations and
+there are lots of concurrent search-index updates, you might want
+opt for a cron job invoking :meth:`whooshee.reindex()` periodically
+instead of employing the default index auto-updating mechanism.
+
+This is especially recommended, if you encouter ``LockError`` raised
+by python-whoosh module and setting ``WHOOSHEE_WRITER_TIMEOUT``
+to a higher value (default is 2) does not help.
+
+To disable index auto updating, set ``auto_update`` class property of
+a Whoosheer to ``False``::
+
+    @whooshee.register_whoosheer
+    class NewEntryUserWhoosheer(EntryUserWhoosheer):
+        auto_update = False
 
 API
 ---

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -128,6 +128,8 @@ class AbstractWhoosheer(object):
       searched.
     """
 
+    auto_update = True
+
     @classmethod
     def search(cls, search_string, values_of='', group=whoosh.qparser.OrGroup, match_substrings=True, limit=None):
         """Searches the fields for given search_string.
@@ -395,6 +397,8 @@ class Whooshee(object):
         to do the actual index writing.
         """
         for wh in self.whoosheers:
+            if not wh.auto_update:
+                continue
             writer = None
             for change in changes:
                 if change[0].__class__ in wh.models:

--- a/test.py
+++ b/test.py
@@ -117,6 +117,23 @@ class BaseTestCases(object):
             found = self.Entry.query.whooshee_search('not there!').all()
             self.assertEqual(len(found), 0)
 
+        def test_no_autoupdate(self):
+            for whoosheer in self.wh.whoosheers:
+                whoosheer.auto_update = False
+            self.db.session.add(self.u1)
+            self.db.session.commit()
+
+            found = self.Entry.query.whooshee_search('chuck').all()
+            self.assertEqual(len(found), 0) # nothing is found
+
+            for whoosheer in self.wh.whoosheers:
+                whoosheer.auto_update = True
+            self.db.session.add(self.u2)
+            self.db.session.commit()
+
+            found = self.Entry.query.whooshee_search('arnold').all()
+            self.assertEqual(len(found), 1) # arnold is found
+
         def test_mw_result_in_different_fields(self):
             self.db.session.add_all(self.all_inst)
             self.db.session.commit()


### PR DESCRIPTION
Decides if a whoosheer should be updated by on_commit method.

Default value is True and it can be changed in a user-specified whoosheer:

```
@whooshee.register_whoosheer
class CoprWhoosheer(AbstractWhoosheer):
   schema = whoosh.fields.Schema(
        copr_id=whoosh.fields.NUMERIC(stored=True, unique=True)
   )

  auto_update = False
```

The rationale for this feature is that index updates in our system can take a long time (around 0.8s) and if there are several concurrent requests to update the search index, some of them occasionally time out with 'LockError'. That's why we need to switch from continuous auto-updating of the search index to updating in batches (every hour, e.g.) and only for those records that have been modified (this is covered by a piece of custom logic). 

The optimization here is that if a db record was modified many times in the passed hour, the search index record will be modified only once. Also search index updating will become sequential and hence proof to lock errors caused by many concurrent accesses. 

Our index has become very large lately and that is why we need this. I'll add README and tests if you will agree with this feature.
