### PR TITLE
Fix typo in config and deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Entry.query.whooshee_search('chuck norris', whoosheer=EntryUserWhoosheer).order_
 ```
 If there exists an entry of a user called 'chuck norris', this entry will be found because the custom whoosheer, that contains field `username`, will be used. But without the whoosheer option, that entry won't be found (unless it has 'chuck&nbsp;norris' in content or title) because the model whoosheer will be used.
 
+### Configuration
+
+Following configuration options are available:
+
+| Option                      | Description                                                           |
+| --------------------------- | --------------------------------------------------------------------- |
+| ``WHOOSHEE_DIR``            | The path for the whoosh index (defaults to **whooshee**)              |
+| ``WHOOSHEE_MIN_STRING_LEN`` | Min. characters for the search string (defaults to **3**)             |
+| ``WHOOSHEE_WRITER_TIMEOUT`` | How long should whoosh try to acquire write lock? (defaults to **2**) |
+
 ### Reindex
 
 Available since v0.0.9.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ flask-whooshee is based on so-called whoosheers. These represent Whoosh indexes 
 
 ```python
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.whooshee import Whooshee
+from flask_sqlalchemy import SQLAlchemy
+from flask_whooshee import Whooshee
 
 app = Flask(__name__)
 app.config['WHOOSHEE_DIR'] = '/tmp/whoosheers'
@@ -36,8 +36,8 @@ The more complicated custom whoosheers allow you to create indexes and search ac
 
 ```python
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.whooshee import Whooshee, AbstractWhoosheer
+from flask_sqlalchemy import SQLAlchemy
+from flask_whooshee import Whooshee, AbstractWhoosheer
 
 app = Flask(__name__)
 app.config['WHOOSHEE_DIR'] = /tmp/whoosheers
@@ -144,7 +144,7 @@ Available since v0.0.9.
 If you lost your whooshee data and you need to recreate it, you can run inside Flask application context:
 
 ```
-from flask.ext.whooshee import Whooshee
+from flask_whooshee import Whooshee
 w = Whooshee(app)
 w.reindex()
 ```

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -156,7 +156,7 @@ class Whooshee(object):
     def init_app(self, app):
 
         self.index_path_root = app.config.get('WHOOSHEE_DIR', '') or 'whooshee'
-        self.search_string_min_len = app.config.get('WHOSHEE_MIN_STRING_LEN', 3)
+        self.search_string_min_len = app.config.get('WHOOSHEE_MIN_STRING_LEN', 3)
         self.writer_timeout = app.config.get('WHOOSHEE_WRITER_TIMEOUT', 2)
         models_committed.connect(self.on_commit, sender=app)
         if not os.path.exists(self.index_path_root):

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -10,7 +10,7 @@ import whoosh.fields
 import whoosh.index
 import whoosh.qparser
 
-from flask.ext.sqlalchemy import models_committed, BaseQuery
+from flask_sqlalchemy import models_committed, BaseQuery
 from sqlalchemy import text
 from sqlalchemy.orm.mapper import Mapper
 
@@ -261,7 +261,7 @@ class Whooshee(object):
         wh.index = index
 
     def on_commit(self, app, changes):
-        """Method that gets connected to flask.ext.sqlalchemy.models_committed, where it serves
+        """Method that gets connected to flask_sqlalchemy.models_committed, where it serves
         to do the actual index writing.
         """
         for wh in self.__class__.whoosheers:

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ import string
 
 import whoosh
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 from flask_whooshee import AbstractWhoosheer, Whooshee
 


### PR DESCRIPTION
Hey,
This just fixes a typo in the config (``WHOSHEE_MIN_STRING_LEN`` --> ``WHOOSHEE_MIN_STRING_LEN``) and some of the deprecations warning (Flask >= 0.11 discourages to use [``flask.ext``](http://flask.pocoo.org/docs/0.11/extensiondev/#extension-import-transition))
I have added a table with available config options to the README as well.

btw, I also stumbled (my linter, not me :smile:) across a lot of PEP8 warnings and if you want, I'd fix them too (I'd open a seperate PR for this).