### PR TITLE
Fix attribute search

### DIFF
--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -174,7 +174,7 @@ class AbstractWhoosheer(object):
         if len(s) < _get_config(cls)['search_string_min_len']:
             raise ValueError('Search string must have at least 3 characters')
         # replace multiple with star space star
-        if match_substrings:
+        if match_substrings and ':' not in s:
             s = u'*{0}*'.format(re.sub('[\s]+', '* *', s))
         # TODO: some sanitization
         return s


### PR DESCRIPTION
I'm not completely sure on the logic in `prep_search_string`, but I had a problem where attribute search (e.g. `name:John`) would cause the app to become unresponsive (100% CPU usage). I isolated the cause to be the wrapping search string in stars `*`. This PR should fix this by not wrapping search strings that contain attributes in stars.