### PR TITLE
Fix unicode decode error on Python2

### DIFF
--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -169,8 +169,8 @@ class AbstractWhoosheer(object):
         :param match_substrings: ``True`` if you want to match substrings,
                                  ``False`` otherwise.
         """
-        if sys.version < '3':
-            search_string = unicode(search_string)
+        if sys.version < '3' and not isinstance(search_string, unicode):
+            search_string = search_string.decode('utf-8')
         s = search_string.strip()
         # we don't want stars from user
         s = s.replace('*', '')

--- a/flask_whooshee.py
+++ b/flask_whooshee.py
@@ -170,7 +170,7 @@ class AbstractWhoosheer(object):
                                  ``False`` otherwise.
         """
         if sys.version < '3':
-            search_string = search_string.decode('utf-8')
+            search_string = unicode(search_string)
         s = search_string.strip()
         # we don't want stars from user
         s = s.replace('*', '')


### PR DESCRIPTION
Continues #36.

When passing an Unicode string on Python 2, the `decode()` call will cause an `UnicodeDecodeError`:
```pycon
>>> s = '的'  # s is not unicode type
>>> s.decode('utf-8')  # worked
u'\u7684'
>>> s = u'的'  # now s is already unicode type
>>> s.decode('utf-8')  # bad thing happened
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "C:\Users\Administrator\.virtualenvs\albumy-aCIvDf20\lib\encodings\utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u7684' in position 0: ordinal not in range(128)
```
This PR add a type check before the `decode()` call.
